### PR TITLE
fix issue with -no-viz arg identified in training

### DIFF
--- a/friends_enemies_hybrid.py
+++ b/friends_enemies_hybrid.py
@@ -210,8 +210,9 @@ if __name__ == "__main__":
 
     # Command-line option -no-viz to turn off visualization
     args = sys.argv[1:]
-    if args[0] == '-no-viz':
-        viz = False
+    if len(args) != 0:
+        if args[0] == '-no-viz':
+            viz = False
     else:
         viz = True
 

--- a/friends_enemies_qpu.py
+++ b/friends_enemies_qpu.py
@@ -211,8 +211,9 @@ if __name__ == "__main__":
 
     # Command-line option -no-viz to turn off visualization
     args = sys.argv[1:]
-    if args[0] == '-no-viz':
-        viz = False
+    if len(args) != 0:
+        if args[0] == '-no-viz':
+            viz = False
     else:
         viz = True
 


### PR DESCRIPTION
Remedies an issue where providing no program arguments threw a `IndexError: list index out of range`